### PR TITLE
modify schema to use user and room IDs

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,7 @@ BEGIN;
 
 CREATE TABLE users (
 	user_id SERIAL PRIMARY KEY,
-	username VARCHAR(20),
+	username VARCHAR(20) NOT NULL,
 	is_online BOOLEAN NOT NULL DEFAULT FALSE,
 	is_reddit_linked BOOLEAN NOT NULL DEFAULT FALSE,
 	email TEXT,
@@ -20,7 +20,7 @@ CREATE TABLE users (
 
 CREATE TABLE rooms (
 	room_id SERIAL PRIMARY KEY,
-	name VARCHAR(20),
+	name VARCHAR(20) NOT NULL,
 	topic TEXT,
 	UNIQUE (name)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE users (
 	is_reddit_linked BOOLEAN NOT NULL DEFAULT FALSE,
 	email TEXT,
 	password TEXT,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	CHECK (
 		(is_reddit_linked AND email IS NULL AND password IS NULL) OR
 		(NOT is_reddit_linked AND email IS NOT NULL AND password IS NOT NULL)),
@@ -22,6 +23,7 @@ CREATE TABLE rooms (
 	room_id SERIAL PRIMARY KEY,
 	name VARCHAR(20) NOT NULL,
 	topic TEXT,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	UNIQUE (name)
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -5,7 +5,8 @@ SET search_path = broccoli;
 BEGIN;
 
 CREATE TABLE users (
-	username VARCHAR(20) PRIMARY KEY,
+	user_id SERIAL PRIMARY KEY,
+	username VARCHAR(20),
 	is_online BOOLEAN NOT NULL DEFAULT FALSE,
 	is_reddit_linked BOOLEAN NOT NULL DEFAULT FALSE,
 	email TEXT,
@@ -13,40 +14,43 @@ CREATE TABLE users (
 	CHECK (
 		(is_reddit_linked AND email IS NULL AND password IS NULL) OR
 		(NOT is_reddit_linked AND email IS NOT NULL AND password IS NOT NULL)),
+	UNIQUE (username),
 	UNIQUE (email)
 );
 
 CREATE TABLE rooms (
-	name VARCHAR(20) PRIMARY KEY,
-	topic TEXT
+	room_id SERIAL PRIMARY KEY,
+	name VARCHAR(20),
+	topic TEXT,
+	UNIQUE (name)
 );
 
 CREATE TABLE subscriptions (
-	username VARCHAR(20) NOT NULL,
-	room VARCHAR(20) NOT NULL,
+	user_id INT NOT NULL,
+	room_id INT NOT NULL,
 	is_moderator BOOLEAN NOT NULL DEFAULT FALSE,
 	status TEXT,
-	PRIMARY KEY (username, room),
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE,
-	FOREIGN KEY (room) REFERENCES rooms (name) ON DELETE CASCADE
+	PRIMARY KEY (user_id, room_id),
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+	FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE CASCADE
 );
 
-CREATE INDEX user_sub_index ON subscriptions (username);
-CREATE INDEX room_sub_index ON subscriptions (room);
-CREATE INDEX room_mod_index ON subscriptions (room, is_moderator);
+CREATE INDEX user_sub_index ON subscriptions (user_id);
+CREATE INDEX room_sub_index ON subscriptions (room_id);
+CREATE INDEX room_mod_index ON subscriptions (room_id, is_moderator);
 
 CREATE TYPE message_type AS
 	ENUM ('message', 'join', 'leave', 'kick', 'ban', 'report',
 		'shadowban', 'topic_change', 'status_change');
 
 CREATE TABLE messages (
-	id SERIAL PRIMARY KEY,
-	room VARCHAR(20) NOT NULL,
-	username VARCHAR(20) NOT NULL,
+	message_id SERIAL PRIMARY KEY,
+	room_id INT NOT NULL,
+	user_id INT NOT NULL,
 	time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	type message_type NOT NULL,
 	message TEXT,
-	target_user VARCHAR(20),
+	target_user INT,
 	target_message INT
 	CHECK (
 		((type = 'message' OR type = 'topic_change' OR type = 'status_change') AND
@@ -57,96 +61,95 @@ CREATE TABLE messages (
 			message IS NULL AND target_user IS NULL AND target_message IS NOT NULL) OR
 		((type = 'join' OR type = 'leave') AND
 			message IS NULL AND target_user IS NULL AND target_message IS NULL)),
-	FOREIGN KEY (room) REFERENCES rooms (name) ON DELETE CASCADE,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE,
-	FOREIGN KEY (target_user) REFERENCES users (username) ON DELETE CASCADE,
-	FOREIGN KEY (target_message) REFERENCES messages (id) ON DELETE CASCADE
+	FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE CASCADE,
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+	FOREIGN KEY (target_user) REFERENCES users (user_id) ON DELETE CASCADE,
+	FOREIGN KEY (target_message) REFERENCES messages (message_id) ON DELETE CASCADE
 );
 
-CREATE INDEX room_message_index ON messages (room);
-CREATE INDEX user_message_index ON messages (username);
+CREATE INDEX room_message_index ON messages (room_id);
+CREATE INDEX user_message_index ON messages (user_id);
 
 CREATE TABLE upvotes (
-	message INT NOT NULL,
-	upvoter VARCHAR(20) NOT NULL,
-	PRIMARY KEY (message, upvoter),
-	FOREIGN KEY (message) REFERENCES messages (id) ON DELETE CASCADE,
-	FOREIGN KEY (upvoter) REFERENCES users (username) ON DELETE CASCADE
+	message_id INT NOT NULL,
+	upvoter INT NOT NULL,
+	PRIMARY KEY (message_id, upvoter),
+	FOREIGN KEY (message_id) REFERENCES messages (message_id) ON DELETE CASCADE,
+	FOREIGN KEY (upvoter) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
-CREATE INDEX message_upvotes ON upvotes (message);
+CREATE INDEX message_upvotes ON upvotes (message_id);
 
 CREATE TABLE reports (
-	message INT NOT NULL,
-	reporter VARCHAR(20) NOT NULL,
-	PRIMARY KEY (message, reporter),
-	FOREIGN KEY (message) REFERENCES messages (id) ON DELETE CASCADE,
-	FOREIGN KEY (reporter) REFERENCES users (username) ON DELETE CASCADE
+	message_id INT NOT NULL,
+	reporter INT NOT NULL,
+	PRIMARY KEY (message_id, reporter),
+	FOREIGN KEY (message_id) REFERENCES messages (message_id) ON DELETE CASCADE,
+	FOREIGN KEY (reporter) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
-CREATE INDEX message_reports ON reports (message);
+CREATE INDEX message_reports ON reports (message_id);
 
 CREATE TABLE bans (
-	room VARCHAR(20) NOT NULL,
-	username VARCHAR(20) NOT NULL,
-	FOREIGN KEY (room) REFERENCES rooms (name) ON DELETE CASCADE,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE
+	room_id INT NOT NULL,
+	user_id INT NOT NULL,
+	FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE CASCADE,
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
-CREATE INDEX room_bans_index ON bans (room);
-CREATE INDEX user_bans_index ON bans (username);
+CREATE INDEX room_bans_index ON bans (room_id);
 
 CREATE TABLE shadowbans (
-	room VARCHAR(20) NOT NULL,
-	username VARCHAR(20) NOT NULL,
-	FOREIGN KEY (room) REFERENCES rooms (name) ON DELETE CASCADE,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE
+	room_id INT NOT NULL,
+	user_id INT NOT NULL,
+	FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE CASCADE,
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
-CREATE INDEX room_shadowbans_index ON shadowbans (room);
+CREATE INDEX room_shadowbans_index ON shadowbans (room_id);
 
 CREATE TABLE blocked_users (
-	username VARCHAR(20) NOT NULL,
-	target_user VARCHAR(20) NOT NULL,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE,
-	FOREIGN KEY (target_user) REFERENCES users (username) ON DELETE CASCADE
+	user_id INT NOT NULL,
+	target_user INT NOT NULL,
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+	FOREIGN KEY (target_user) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
 CREATE TABLE groups (
-	id SERIAL PRIMARY KEY,
+	group_id SERIAL PRIMARY KEY,
 	topic TEXT
 );
 
 CREATE TABLE group_subscriptions (
-	username VARCHAR(20) NOT NULL,
+	user_id INT NOT NULL,
 	group_id INT,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE,
-	FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+	FOREIGN KEY (group_id) REFERENCES groups (group_id) ON DELETE CASCADE
 );
 
 CREATE TABLE group_messages (
-	id SERIAL PRIMARY KEY,
+	message_id SERIAL PRIMARY KEY,
 	group_id INT NOT NULL,
-	username VARCHAR(20) NOT NULL,
+	user_id INT NOT NULL,
 	time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	type message_type NOT NULL,
 	message TEXT,
 	CHECK (
 		((type = 'message' OR type = 'topic_change') AND message IS NOT NULL) OR
 		((type = 'join' OR type = 'leave') AND message IS NULL)),
-	FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE,
-	FOREIGN KEY (username) REFERENCES users (username) ON DELETE CASCADE
+	FOREIGN KEY (group_id) REFERENCES groups (group_id) ON DELETE CASCADE,
+	FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
 CREATE INDEX group_message_index ON group_messages (group_id);
-CREATE INDEX user_group_message_index ON group_messages (username);
+CREATE INDEX user_group_message_index ON group_messages (user_id);
 
 CREATE TABLE group_upvotes (
-	message INT NOT NULL,
-	upvoter VARCHAR(20) NOT NULL,
-	PRIMARY KEY (message, upvoter),
-	FOREIGN KEY (message) REFERENCES group_messages (id) ON DELETE CASCADE,
-	FOREIGN KEY (upvoter) REFERENCES users (username) ON DELETE CASCADE
+	message_id INT NOT NULL,
+	upvoter INT NOT NULL,
+	PRIMARY KEY (message_id, upvoter),
+	FOREIGN KEY (message_id) REFERENCES group_messages (message_id) ON DELETE CASCADE,
+	FOREIGN KEY (upvoter) REFERENCES users (user_id) ON DELETE CASCADE
 );
 
 COMMIT;


### PR DESCRIPTION
The original schema has usernames and room names as primary keys. This PR introduces user and room IDs as primary keys and demotes names to unique keys, introducing the possibility of them being changed in the future.
